### PR TITLE
Benchmark memory

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -58,56 +58,20 @@ jobs:
                         benchmark \
                         .build/release/FirewallUsage 66.249.66.169
 
-            -   name: Run test application (140MB memory limit)
+            -   name: Run test application (155MB memory limit)
                 run: |
                     docker run --rm -v=$PWD:/swift -w=/swift \
-                        --memory-swap 140m \
-                        --memory 140m \
+                        --memory-swap 155m \
+                        --memory 155m \
                         -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage 66.249.66.169
 
-            -   name: Run test application (130MB memory limit)
+            -   name: Run test application (150MB memory limit)
                 run: |
                     docker run --rm -v=$PWD:/swift -w=/swift \
-                        --memory-swap 130m \
-                        --memory 130m \
-                        -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
-                        benchmark \
-                        .build/release/FirewallUsage 66.249.66.169
-
-            -   name: Run test application (120MB memory limit)
-                run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift \
-                        --memory-swap 120m \
-                        --memory 120m \
-                        -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
-                        benchmark \
-                        .build/release/FirewallUsage 66.249.66.169
-
-            -   name: Run test application (100MB memory limit)
-                run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift \
-                        --memory-swap 100m \
-                        --memory 100m \
-                        -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
-                        benchmark \
-                        .build/release/FirewallUsage 66.249.66.169
-
-            -   name: Run test application (80MB memory limit)
-                run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift \
-                        --memory-swap 80m \
-                        --memory 80m \
-                        -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
-                        benchmark \
-                        .build/release/FirewallUsage 66.249.66.169
-
-            -   name: Run test application (60MB memory limit)
-                run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift \
-                        --memory-swap 60m \
-                        --memory 60m \
+                        --memory-swap 150m \
+                        --memory 150m \
                         -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage 66.249.66.169

--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     linux:
         runs-on: ubuntu-24.04
-        name: Benchmark memory consumption
+        name: memory consumption
         steps:
             -   name: Checkout repository
                 uses: actions/checkout@v3
@@ -31,30 +31,30 @@ jobs:
                         benchmark \
                         Scripts/Package
 
+            -   name: Run test application (300MB memory limit)
+                run: |
+                    docker run --rm -v=$PWD:/swift -w=/swift --memory 300m \
+                        -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
+                        benchmark \
+                        .build/release/FirewallUsage 66.249.66.169
+
             -   name: Run test application (200MB memory limit)
                 run: |
                     docker run --rm -v=$PWD:/swift -w=/swift --memory 200m \
                         -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
-                        .build/release/FirewallUsage
+                        .build/release/FirewallUsage 66.249.66.169
 
-            -   name: Run test application (150MB memory limit)
+            -   name: Run test application (160MB memory limit)
                 run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift --memory 150m \
+                    docker run --rm -v=$PWD:/swift -w=/swift --memory 160m \
                         -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
-                        .build/release/FirewallUsage
+                        .build/release/FirewallUsage 66.249.66.169
 
-            -   name: Run test application (100MB memory limit)
+            -   name: Run test application (140MB memory limit)
                 run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift --memory 100m \
+                    docker run --rm -v=$PWD:/swift -w=/swift --memory 140m \
                         -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
-                        .build/release/FirewallUsage
-
-            -   name: Run test application (80MB memory limit)
-                run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift --memory 80m \
-                        -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
-                        benchmark \
-                        .build/release/FirewallUsage
+                        .build/release/FirewallUsage 66.249.66.169

--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -33,23 +33,27 @@ jobs:
             -   name: Run test application (200MB memory limit)
                 run: |
                     docker run --rm -v=$PWD:/swift -w=/swift --memory 200m \
+                        -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage
 
             -   name: Run test application (150MB memory limit)
                 run: |
                     docker run --rm -v=$PWD:/swift -w=/swift --memory 150m \
+                        -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage
 
             -   name: Run test application (100MB memory limit)
                 run: |
                     docker run --rm -v=$PWD:/swift -w=/swift --memory 100m \
+                        -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage
 
             -   name: Run test application (80MB memory limit)
                 run: |
                     docker run --rm -v=$PWD:/swift -w=/swift --memory 80m \
+                        -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage

--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     linux:
         runs-on: ubuntu-24.04
-        name: Ubuntu 24.04
+        name: Benchmark memory consumption
         steps:
             -   name: Checkout repository
                 uses: actions/checkout@v3
@@ -27,6 +27,7 @@ jobs:
             -   name: Build firewall
                 run: |
                     docker run --rm -v=$PWD:/swift -w=/swift \
+                        -e IPINFO_TOKEN=${{ secrets.IPINFO_TOKEN }} \
                         benchmark \
                         Scripts/Package
 

--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -58,3 +58,17 @@ jobs:
                         -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage 66.249.66.169
+
+            -   name: Run test application (130MB memory limit)
+                run: |
+                    docker run --rm -v=$PWD:/swift -w=/swift --memory 130m \
+                        -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
+                        benchmark \
+                        .build/release/FirewallUsage 66.249.66.169
+
+            -   name: Run test application (120MB memory limit)
+                run: |
+                    docker run --rm -v=$PWD:/swift -w=/swift --memory 120m \
+                        -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
+                        benchmark \
+                        .build/release/FirewallUsage 66.249.66.169

--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -33,63 +33,81 @@ jobs:
 
             -   name: Run test application (300MB memory limit)
                 run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift --memory 300m \
+                    docker run --rm -v=$PWD:/swift -w=/swift \
+                        --memory-swap 300m \
+                        --memory 300m \
                         -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage 66.249.66.169
 
             -   name: Run test application (200MB memory limit)
                 run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift --memory 200m \
+                    docker run --rm -v=$PWD:/swift -w=/swift \
+                        --memory-swap 200m \
+                        --memory 200m \
                         -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage 66.249.66.169
 
             -   name: Run test application (160MB memory limit)
                 run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift --memory 160m \
+                    docker run --rm -v=$PWD:/swift -w=/swift \
+                        --memory-swap 160m \
+                        --memory 160m \
                         -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage 66.249.66.169
 
             -   name: Run test application (140MB memory limit)
                 run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift --memory 140m \
+                    docker run --rm -v=$PWD:/swift -w=/swift \
+                        --memory-swap 140m \
+                        --memory 140m \
                         -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage 66.249.66.169
 
             -   name: Run test application (130MB memory limit)
                 run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift --memory 130m \
+                    docker run --rm -v=$PWD:/swift -w=/swift \
+                        --memory-swap 130m \
+                        --memory 130m \
                         -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage 66.249.66.169
 
             -   name: Run test application (120MB memory limit)
                 run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift --memory 120m \
+                    docker run --rm -v=$PWD:/swift -w=/swift \
+                        --memory-swap 120m \
+                        --memory 120m \
                         -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage 66.249.66.169
 
             -   name: Run test application (100MB memory limit)
                 run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift --memory 100m \
+                    docker run --rm -v=$PWD:/swift -w=/swift \
+                        --memory-swap 100m \
+                        --memory 100m \
                         -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage 66.249.66.169
 
             -   name: Run test application (80MB memory limit)
                 run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift --memory 80m \
+                    docker run --rm -v=$PWD:/swift -w=/swift \
+                        --memory-swap 80m \
+                        --memory 80m \
                         -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage 66.249.66.169
 
             -   name: Run test application (60MB memory limit)
                 run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift --memory 60m \
+                    docker run --rm -v=$PWD:/swift -w=/swift \
+                        --memory-swap 60m \
+                        --memory 60m \
                         -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage 66.249.66.169

--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -72,3 +72,24 @@ jobs:
                         -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage 66.249.66.169
+
+            -   name: Run test application (100MB memory limit)
+                run: |
+                    docker run --rm -v=$PWD:/swift -w=/swift --memory 100m \
+                        -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
+                        benchmark \
+                        .build/release/FirewallUsage 66.249.66.169
+
+            -   name: Run test application (80MB memory limit)
+                run: |
+                    docker run --rm -v=$PWD:/swift -w=/swift --memory 80m \
+                        -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
+                        benchmark \
+                        .build/release/FirewallUsage 66.249.66.169
+
+            -   name: Run test application (60MB memory limit)
+                run: |
+                    docker run --rm -v=$PWD:/swift -w=/swift --memory 60m \
+                        -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
+                        benchmark \
+                        .build/release/FirewallUsage 66.249.66.169

--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -57,21 +57,3 @@ jobs:
                         -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
                         benchmark \
                         .build/release/FirewallUsage 66.249.66.169
-
-            -   name: Run test application (155MB memory limit)
-                run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift \
-                        --memory-swap 155m \
-                        --memory 155m \
-                        -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
-                        benchmark \
-                        .build/release/FirewallUsage 66.249.66.169
-
-            -   name: Run test application (150MB memory limit)
-                run: |
-                    docker run --rm -v=$PWD:/swift -w=/swift \
-                        --memory-swap 150m \
-                        --memory 150m \
-                        -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
-                        benchmark \
-                        .build/release/FirewallUsage 66.249.66.169

--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -1,0 +1,55 @@
+name: benchmark
+
+on:
+    push:
+        branches: [ master ]
+    pull_request:
+        branches: [ master ]
+
+jobs:
+    linux:
+        runs-on: ubuntu-24.04
+        name: Ubuntu 24.04
+        steps:
+            -   name: Checkout repository
+                uses: actions/checkout@v3
+
+            -   name: Build environment
+                run: |
+                    docker build -f Benchmarks/Memory/Dockerfile -t benchmark .
+
+            -   name: Build test application
+                run: |
+                    docker run --rm -v=$PWD:/swift -w=/swift \
+                        benchmark \
+                        swift build -c release --product FirewallUsage
+
+            -   name: Build firewall
+                run: |
+                    docker run --rm -v=$PWD:/swift -w=/swift \
+                        benchmark \
+                        Scripts/Package
+
+            -   name: Run test application (200MB memory limit)
+                run: |
+                    docker run --rm -v=$PWD:/swift -w=/swift --memory 200m \
+                        benchmark \
+                        .build/release/FirewallUsage
+
+            -   name: Run test application (150MB memory limit)
+                run: |
+                    docker run --rm -v=$PWD:/swift -w=/swift --memory 150m \
+                        benchmark \
+                        .build/release/FirewallUsage
+
+            -   name: Run test application (100MB memory limit)
+                run: |
+                    docker run --rm -v=$PWD:/swift -w=/swift --memory 100m \
+                        benchmark \
+                        .build/release/FirewallUsage
+
+            -   name: Run test application (80MB memory limit)
+                run: |
+                    docker run --rm -v=$PWD:/swift -w=/swift --memory 80m \
+                        benchmark \
+                        .build/release/FirewallUsage

--- a/Benchmarks/Memory/Dockerfile
+++ b/Benchmarks/Memory/Dockerfile
@@ -1,4 +1,4 @@
 FROM swift:6.0.2-noble
 
 RUN apt update
-RUN apt -y install libjemalloc2
+RUN apt -y install libjemalloc2 curl gzip

--- a/Benchmarks/Memory/Dockerfile
+++ b/Benchmarks/Memory/Dockerfile
@@ -1,2 +1,4 @@
 FROM swift:6.0.2-noble
+
+RUN apt update
 RUN apt -y install libjemalloc2

--- a/Benchmarks/Memory/Dockerfile
+++ b/Benchmarks/Memory/Dockerfile
@@ -1,0 +1,2 @@
+FROM swift:6.0.2-noble
+RUN apt -y install libjemalloc2

--- a/Snippets/FirewallUsage.swift
+++ b/Snippets/FirewallUsage.swift
@@ -30,33 +30,34 @@ else
     fatalError("Invalid IP address")
 }
 
+//  snippet.LOAD_FIREWALL
 let data:Data = try .init(contentsOf: URL.init(fileURLWithPath: "firewall.bson"))
 let bson:BSON.Document = .init(bytes: [UInt8].init(data)[...])
 
 let firewall:IP.Firewall = .load(from: try IP.Firewall.Image.init(bson: bson))
 
-guard
-let country:ISO.Country = firewall.country[v6: ip]
-else
+//  snippet.LOOKUP_COUNTRY
+let country:ISO.Country? = firewall.country[v6: ip]
+//  snippet.end
+if  let country:ISO.Country
 {
-    fatalError("No Country found for \(ip)")
+    print("Country: \(country)")
 }
 
-print("""
-    Address: \(ip)
-    Country: \(country)
-    """)
-
-let (system, _):(IP.AS?, IP.Claimant?) = firewall.lookup(v6: ip)
-
-guard
-let system:IP.AS
-else
+//  snippet.LOOKUP_ASN
+let (system, claimant):(IP.AS?, IP.Claimant?) = firewall.lookup(v6: ip)
+//  snippet.end
+if  let system:IP.AS
 {
-    fatalError("No ASN found for \(ip)")
+    print("""
+        ASN: \(system.number)
+        AS: \(system.domain) (\(system.name))
+        """)
 }
 
-print("""
-    ASN: \(system.number)
-    AS: \(system.domain) (\(system.name))
-    """)
+if  let claimant:IP.Claimant
+{
+    print("""
+        Claimant: \(claimant)
+        """)
+}

--- a/Sources/FirewallPrefabricator/Main.swift
+++ b/Sources/FirewallPrefabricator/Main.swift
@@ -4,8 +4,6 @@ import FoundationEssentials
 import Foundation
 #endif
 
-// $ docker run --rm -it -p 8443:8443 --network=unidoc-test --memory 20m -v ~/swift:/swift -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 -w /swift/swiftinit tayloraswift/ubuntu:latest /bin/bash
-
 import ArgumentParser
 import BSON
 import Firewalls
@@ -82,6 +80,9 @@ extension Main
         try image.colorByClaimant(claims)
 
         let bson:BSON.Document = .init(encoding: image)
+
+        print("Successfully built firewall image (\(bson.bytes.count / 1_000) KB)")
+
         try Data.init(bson.bytes).write(to: URL.init(fileURLWithPath: self.output))
     }
 }


### PR DESCRIPTION
this PR adds hard memory consumption benchmarks to validate the absolute minimum RAM needed to use the Firewall, which is currently about 160 MB. this figure makes a lot of sense, the Firewall itself is about 63 MB, and we need to copy the buffer once in order to turn `Foundation.Data` into `[UInt8]`, which would transiently use 126 MB of RAM. the remaining memory can be attributed to the test application itself, and its linked libraries:

```
     63 MB — Used by IP.Firewall itself
     63 MB — Used by Foundation.Data (would not appear in production)
     34 MB — Used by the test application, including the Swift stdlib
    2.6 MB — libstdc++.so.6
    2.1 MB — libc.so.6
    1.0 MB — libm.so.6
+   0.2 MB — libgcc_s.so.1
——————————
    165 MB
``` 

i guess the C/C++ libraries get loaded lazily, which is why the benchmark squeaks by with 160 MB of RAM and no swap.