### PR TITLE
readable symbol links

### DIFF
--- a/Sources/IP/IP.Block.swift
+++ b/Sources/IP/IP.Block.swift
@@ -36,13 +36,13 @@ extension IP.Block<IP.V6>
 
     /// Returns the IPv6 loopback mask, `::1/128`.
     @inlinable public
-    static var loopback:Self { .init(base: .localhost, bits: 128) }
+    static var loopback:IP.Block<IP.V6> { .init(base: .localhost, bits: 128) }
 }
 extension IP.Block<IP.V4>
 {
     /// Returns the IPv4 loopback mask, `127.0.0.0/8`.
     @inlinable public
-    static var loopback:Self { .init(base: .localhost, bits: 8) }
+    static var loopback:IP.Block<IP.V4> { .init(base: .localhost, bits: 8) }
 }
 extension IP.Block
 {

--- a/Sources/IP/IP.V4.swift
+++ b/Sources/IP/IP.V4.swift
@@ -31,7 +31,8 @@ extension IP.V4
 extension IP.V4
 {
     /// Returns the most common loopback address, `127.0.0.1`. Most people reaching for this
-    /// API actually want ``IP.Block.loopback [5JXTL]``, which models the entire loopback range.
+    /// API actually want ``IP.Block.loopback -> IP.Block<IP.V6>``, which models the entire
+    /// loopback range.
     @inlinable public
     static var localhost:Self { .init(value: 0x7F_00_00_01) }
 }


### PR DESCRIPTION
we need to adjust the source code to work around the Unidoc bug https://github.com/tayloraswift/swift-unidoc/issues/385 , which is a wrapper around a Swift compiler bug.